### PR TITLE
Add a Support and Stability Policy

### DIFF
--- a/support-policy.md
+++ b/support-policy.md
@@ -1,0 +1,34 @@
+Support and Stability policy
+============================
+
+With regards to current and future releases the OpenSSL project has adopted the
+following policy:
+
+* Version 3.0 will be supported until 2023-09-07.
+* Version 1.1.1 will be supported until 2023-09-11 (LTS).
+* Version 1.0.2 is no longer supported. Extended support for 1.0.2 to gain
+access to security fixes for that version is
+[available](https://www.openssl.org/support/contracts.html).
+* Versions 1.1.0, 1.0.1, 1.0.0 and 0.9.8 are no longer supported.
+
+We may designate a release as a Long Term Support (LTS) release. LTS releases
+will be supported for at least five years and we will specify one at least every
+four years. Non-LTS releases will be supported for at least two years.
+
+During the final year of support, we do not commit to anything other than
+security fixes. Before that, bug and security fixes will be applied as
+appropriate.
+
+Stability
+---------
+
+No API or ABI breaking changes are allowed in a minor or patch release.
+
+No existing public interface can be removed until its replacement has been in
+place in an LTS stable release. The original interface must also have been
+documented as deprecated for at least 5 years. A public interface is any
+function, structure or macro declared in a public header file.
+
+Refer to the OTC's
+[Stable Release Updates Policy](https://github.com/openssl/technical-policies/blob/master/policies/stable-release-updates.md)
+for further details.


### PR DESCRIPTION
This text is mostly just lifted from https://www.openssl.org/policies/releasestrat.html and converted to markdown. Aside from some minor editorial tweaks there is no new policy text here.

I've dropped some statements from the the above link. Specifically these ones:

* No existing public interface can be modified except where changes are unlikely to break source compatibility or where structures are made opaque.
* When structures are made opaque, any newly required accessor macros or functions are added in a feature release of the extant LTS release and all supported intermediate successor releases.

It seems to me that, *if* we want to retain these statements then they would be more properly placed in the OTC's Stable Release Updates Policy.