### PR TITLE
Committer Policy

### DIFF
--- a/policies/committer-policy.md
+++ b/policies/committer-policy.md
@@ -1,0 +1,93 @@
+
+# Policy for OpenSSL Committers
+
+## Who is a committer?
+
+OpenSSL committers are contributors who have commit access to the OpenSSL
+source code repository.  Committers review and commit their own patches
+as well as those of other contributors.
+
+## How to become a committer?
+
+Commit access is granted by the OpenSSL Management Committee (OMC)
+typically on the recommendation of the OpenSSL Technical Committee (OTC)
+(see the OpenSSL Bylaws).
+
+We welcome contributors who become domain experts in some part of
+the library (for example, low-level crypto) as well as generalists
+who contribute to all areas of the codebase.  All committers share
+the responsibility for the overall health of the project: aside from
+contributing quality features, committers are team players who fix bugs,
+address open issues, review community contributions, and improve tests
+and documentation.  Committers are also shepherds of the OpenSSL community
+and its code of conduct.
+
+To become a committer, start by contributing code.  Read our coding style,
+and get to know our build and test system.  Then, use the Github issue
+tracker, and our mailing lists find impactful ideas to work on.
+
+## How to maintain committer status?
+
+To maintain committer status, you must stay active in the project.  Refer
+to the OpenSSL Bylaws for details.
+
+In the unlikely and unfortunate event that your actions conflict with
+the project objectives or are otherwise disruptive, committer status
+may also be revoked by the OMC.
+
+## Approvals and code reviews
+
+All submissions must be reviewed and approved by at least two committers,
+one of whom must also be an OTC member.  If the author is also a committer
+then that counts as one of the reviews.  In other words:
+
+* OTC members need one approval from any committer
+* Committers need one approval from an OTC member
+* Contributors without commit rights need two approvals, including
+  one from an OTC member.
+
+An OMC member may apply an OMC-hold to a submission.  An OTC member may
+apply an OTC-hold to a submission.  An OMC-hold may be cleared by being
+removed by the member that put in place the hold or by a vote of the
+OMC.  An OTC-hold may be cleared by being removed by the member that put
+in place the hold or by a vote of the OTC.
+
+Approved submissions (outside of the automated release process and NEWS.md
+and CHANGES.md file updates) shall only be applied after a 24-hour delay from
+the approval (except for minor build and test breakage fix approvals).
+
+Contributors without commit rights cannot formally approve patches but
+are nevertheless welcome to comment on submissions and do technical
+reviews.  We always value another pair of eyes, and volunteering for
+reviews counts favourably towards becoming a committer.  As an author,
+we ask that you address all comments, even if you already have the
+necessary approvals.
+
+If you have trouble finding consensus on a difficult review, reach out to
+the OTC at otc@openssl.org (private, moderated) or the project
+at openssl-project@openssl.org (public, moderated).  On GitHub, you can
+target the OMC members with @openssl/omc, OTC members with @openssl/otc,
+or committers with @openssl/committers.
+
+## Commit workflow
+
+We do code reviews on GitHub.  The OpenSSL GitHub repository is a mirror,
+so we do not merge on GitHub.  When you become a committer, we'll send
+you instructions to get commit access to the main repository.  To have
+handy links to review history, we record the reviewers and GitHub pull
+request IDs in commit headers.  We have some helper scripts in the tools
+repo to add these headers automatically.
+
+We don't use merge commits.
+
+If at any point during development or review you discover a potential
+security issue, we ask that you report it to openssl-security@openssl.org
+and don't discuss it further in public.  We review security issues
+privately, however acceptance of a submission for a security issue does
+not bypass the review process that applies to all submissions.
+
+## A note on CLAs
+
+All authors, including committers, must have current CLAs on file.  A CLA
+is not required for trivial contributions (e.g. the fix of a spelling
+mistake).  Refer to the CLA page for further details.

--- a/policies/committer-policy.md
+++ b/policies/committer-policy.md
@@ -9,9 +9,8 @@ as well as those of other contributors.
 
 ## How to become a committer?
 
-Commit access is granted by the OpenSSL Management Committee (OMC)
-typically on the recommendation of the OpenSSL Technical Committee (OTC)
-(see the OpenSSL Bylaws).
+Commit access is granted by a vote of the [OMC] typically on the
+recommendation of the [OTC] (see the [OpenSSL Bylaws]).
 
 We welcome contributors who become domain experts in some part of
 the library (for example, low-level crypto) as well as generalists
@@ -24,7 +23,7 @@ and its code of conduct.
 
 To become a committer, start by contributing code.  Read our coding style,
 and get to know our build and test system.  Then, use the Github issue
-tracker, and our mailing lists find impactful ideas to work on.
+tracker, and our mailing lists to find impactful ideas to work on.
 
 ## How to maintain committer status?
 
@@ -46,15 +45,18 @@ then that counts as one of the reviews.  In other words:
 * Contributors without commit rights need two approvals, including
   one from an OTC member.
 
-An OMC member may apply an OMC-hold to a submission.  An OTC member may
-apply an OTC-hold to a submission.  An OMC-hold may be cleared by being
-removed by the member that put in place the hold or by a vote of the
-OMC.  An OTC-hold may be cleared by being removed by the member that put
-in place the hold or by a vote of the OTC.
+An OMC member may apply a _hold: needs OMC decision_ label to a submission.
+An OTC member may apply a _hold: needs OTC decision_ to a submission.
+A _hold: needs OMC decision_ label may be removed by the member that put
+in place the hold or by a decision of the OMC.
+A _hold: needs OTC decision_ label may be removed by the member that put
+in place the hold or by a decision of the OTC.
 
-Approved submissions (outside of the automated release process and NEWS.md
-and CHANGES.md file updates) shall only be applied after a 24-hour delay from
-the approval (except for minor build and test breakage fix approvals).
+Approved submissions (outside of the automated release process and
+[NEWS] and [CHANGES] file updates) shall only be applied after a 24-hour
+delay from the approval.  An exception to the delay exists for build and
+test breakage fix approvals which should be flagged with the _severity:
+urgent_ label.
 
 Contributors without commit rights cannot formally approve patches but
 are nevertheless welcome to comment on submissions and do technical
@@ -64,10 +66,10 @@ we ask that you address all comments, even if you already have the
 necessary approvals.
 
 If you have trouble finding consensus on a difficult review, reach out to
-the OTC at otc@openssl.org (private, moderated) or the project
-at openssl-project@openssl.org (public, moderated).  On GitHub, you can
-target the OMC members with @openssl/omc, OTC members with @openssl/otc,
-or committers with @openssl/committers.
+the OTC at `otc@openssl.org` (private, moderated) or the project
+at `openssl-project@openssl.org` (public, moderated).  On GitHub, you can
+reach the OMC members with `@openssl/omc`, OTC members with `@openssl/otc`,
+or committers with `@openssl/committers`.
 
 ## Commit workflow
 
@@ -81,13 +83,27 @@ repo to add these headers automatically.
 We don't use merge commits.
 
 If at any point during development or review you discover a potential
-security issue, we ask that you report it to openssl-security@openssl.org
+security issue, we ask that you report it to `openssl-security@openssl.org`
 and don't discuss it further in public.  We review security issues
 privately, however acceptance of a submission for a security issue does
 not bypass the review process that applies to all submissions.
 
-## A note on CLAs
+## CLAs
 
-All authors, including committers, must have current CLAs on file.  A CLA
-is not required for trivial contributions (e.g. the fix of a spelling
-mistake).  Refer to the CLA page for further details.
+All authors, including committers, must have current [CLAs] on file.
+Refer to the [Contributor Agreements] page for further details.
+
+## Trivial submissions
+
+A CLA is not required for trivial contributions (e.g. the fix of a
+spelling mistake).  All reviewers and the submission author need to
+agree that a submission is trivial and the _cla: trivial_ label should
+be applied to indicate this.
+
+[Contributor Agreements]: https://www.openssl.org/policies/cla.html
+[OpenSSL Bylaws]: https://www.openssl.org/policies/omc-bylaws.html
+[OMC]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#omc
+[OTC]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#otc
+[CLAs]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#cla
+[NEWS]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#news
+[CHANGES]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#changes

--- a/policies/committer-policy.md
+++ b/policies/committer-policy.md
@@ -37,13 +37,15 @@ may also be revoked by the OMC.
 ## Approvals and code reviews
 
 All submissions must be reviewed and approved by at least two committers,
-one of whom must also be an OTC member.  If the author is also a committer
-then that counts as one of the reviews.  In other words:
+one of whom must also be an OTC member.  Neither of the reviewers can
+be the author of the submission.
 
-* OTC members need one approval from any committer
-* Committers need one approval from an OTC member
-* Contributors without commit rights need two approvals, including
-  one from an OTC member.
+The sole exception to this is during the release process where the
+author's review does count towards the two needed for the automated
+release process and [NEWS] and [CHANGES] file updates.
+
+In the case where two committers make a joint submission, they can review
+each other's code but not their own.  A third reviewer will be required.
 
 An OMC member may apply a _hold: needs OMC decision_ label to a submission.
 An OTC member may apply a _hold: needs OTC decision_ to a submission.
@@ -53,7 +55,7 @@ A _hold: needs OTC decision_ label may be removed by the member that put
 in place the hold or by a decision of the OTC.
 
 Approved submissions (outside of the automated release process and
-[NEWS] and [CHANGES] file updates) shall only be applied after a 24-hour
+NEWS and CHANGES file updates) shall only be applied after a 24-hour
 delay from the approval.  An exception to the delay exists for build and
 test breakage fix approvals which should be flagged with the _severity:
 urgent_ label.
@@ -107,3 +109,4 @@ be applied to indicate this.
 [CLAs]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#cla
 [NEWS]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#news
 [CHANGES]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#changes
+[OpenSSL Bylaws]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#bylaws

--- a/policies/glossary.md
+++ b/policies/glossary.md
@@ -1,5 +1,10 @@
 # Glossary of OpenSSL terms
 
+This is a _glossary of terms_, it does not include any _formal definitions_ of
+the included terms.  It does, however, link to the _formal definition_ where
+appropriate.  In the event in a conflict between this glossary and the
+_formal definition_, the _formal definition_ is **always** canonical.
+
 ## ABI
 
 _Application binary interface_

--- a/policies/glossary.md
+++ b/policies/glossary.md
@@ -36,6 +36,12 @@ A bug fix is a fix of functionality of the libraries, modules, applications
 or the build system.
 Refer to the [stable release updates policy] for specific details.
 
+## Bylaws
+
+The [OpenSSL Bylaws] provide the rules under which the OpenSSL project operates.
+This includes the [Committer](#committer), [OMC](#omc) and [OTC](#otc) project
+roles and how decisions are made.
+
 ## CCLA
 
 _Corporate Contributor Licence Agreement_
@@ -64,7 +70,7 @@ Also see: [Contributor Agreements], [ICLA](#icla), [CCLA](#ccla)
 
 ## Committer
 
-OpenSSL committers are contributors who have commit access to the OpenSSL
+OpenSSL [committers] are contributors who have commit access to the OpenSSL
 source code repository.
 
 ## End-user documentation
@@ -140,6 +146,7 @@ Refer to the [stable release updates policy] for specific details.
 
 [alpha release]: https://github.com/openssl/general-policies/blob/master/policies/versioning-policy.md#alpha-release
 [beta release]: https://github.com/openssl/general-policies/blob/master/policies/versioning-policy.md#beta-release
+[committers]: https://github.com/openssl/general-policies/blob/master/policies/committer-policy.md
 [Long term support]: https://github.com/openssl/general-policies/blob/master/policies/versioning-policy.md#long-term-stable-release
 [major release]: https://github.com/openssl/general-policies/blob/master/policies/versioning-policy.md#major-release
 [minor release]: https://github.com/openssl/general-policies/blob/master/policies/versioning-policy.md#minor-release
@@ -153,3 +160,4 @@ Refer to the [stable release updates policy] for specific details.
 [OpenSSL Bylaws]: https://www.openssl.org/policies/omc-bylaws.html
 [CHANGES.md]: https://github.com/openssl/openssl/blob/master/CHANGES.md
 [NEWS.md]: https://github.com/openssl/openssl/blob/master/NEWS.md
+[OpenSSL Bylaws]: https://www.openssl.org/policies/omc-bylaws.html

--- a/votes/vote-20220217-committer-policy.txt
+++ b/votes/vote-20220217-committer-policy.txt
@@ -1,0 +1,14 @@
+Topic: Accept the committer policy as of 3766d6ba2648e716e973af6e1821687ad46ee57c
+Proposed by: Pauli
+Issue link: https://github.com/openssl/general-policies/issues/8
+Public: yes
+Opened: 2022-02-17
+Closed: 2022-02-21
+Accepted:  yes  (for: 4, against: 0, abstained: 0, not voted: 2)
+
+  Kurt       [+1]
+  Mark       [  ]
+  Matt       [+1]
+  Pauli      [+1]
+  Richard    [  ]
+  Tim        [+1]


### PR DESCRIPTION
Based over #6 to share the definitions.

Aiming to replace: https://www.openssl.org/policies/committers.html
