### PR TITLE
Remove the double definitions of the OpenSSL Bylaws link.

### DIFF
--- a/policies/committer-policy.md
+++ b/policies/committer-policy.md
@@ -103,7 +103,6 @@ agree that a submission is trivial and the _cla: trivial_ label should
 be applied to indicate this.
 
 [Contributor Agreements]: https://www.openssl.org/policies/cla.html
-[OpenSSL Bylaws]: https://www.openssl.org/policies/omc-bylaws.html
 [OMC]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#omc
 [OTC]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#otc
 [CLAs]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#cla

--- a/policies/glossary.md
+++ b/policies/glossary.md
@@ -193,5 +193,4 @@ Refer to the [stable release updates policy] for specific details.
 [OpenSSL Bylaws]: https://www.openssl.org/policies/omc-bylaws.html
 [CHANGES.md]: https://github.com/openssl/openssl/blob/master/CHANGES.md
 [NEWS.md]: https://github.com/openssl/openssl/blob/master/NEWS.md
-[OpenSSL Bylaws]: https://www.openssl.org/policies/omc-bylaws.html
 [The Linux Documentation Project]: https://tldp.org/


### PR DESCRIPTION
My feeling is that these changes would not be considered a change of policy and could therefore go in without the delays and a vote.

Fixes #13 & #14