### PR TITLE
Add a simple policy for simple policy edits

### DIFF
--- a/policies/policy-change-process.md
+++ b/policies/policy-change-process.md
@@ -4,6 +4,10 @@ Policy on Proposing General Policy Changes
 This policy represents the way that any additions or changes to the existing
 policies are proposed, edited, finalized, and approved.
 
+This policy is only concerned with added or removed policies, or
+changes to the meaning of policies.  Simple corrective changes are
+covered by the [Policy Edit Policy].
+
 Policy Change Proposal
 ----------------------
 
@@ -68,3 +72,4 @@ If the policy change is approved, the pull request is merged to the
 master branch of the general-policies repository.
 
 [OMC]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#omc
+[Policy Edit Process]: policy-edit-process.md

--- a/policies/policy-edit-process.md
+++ b/policies/policy-edit-process.md
@@ -1,0 +1,35 @@
+General Policy Edit Process
+=============================
+
+This policy represents the way that corrective changes to policies, that don't
+change the meaning of those policies, are proposed, edited, and approved.
+
+For substantial policy additions, changes and removals, please see the [Policy
+on Proposing General Policy Changes]
+
+Policy Edit Proposal
+--------------------
+
+The policy edits are submitted as pull requests in the general-policies
+repository on GitHub OpenSSL project. Anyone with a GitHub account can submit
+a policy edit proposal pull request.
+
+Any policy edit proposal SHOULD have a single topic.
+
+The description of the pull request SHOULD provide an overview of the edits
+and the reasons why the edit is proposed.
+
+Review and Approval
+-------------------
+
+Policy edit submissions must be reviewed and approved by at least two
+committers, one of whom must also be an OMC member.  Neither of the reviewers
+can be the author of the submission.
+
+Approved submissions shall only be applied after a 24-hour delay from the
+approval.
+
+If the policy edit is approved, the pull request is merged to the master
+branch of the general-policies repository.
+
+[Policy on Proposing General Policy Changes]: policy-change-process.md


### PR DESCRIPTION
This policy is for simple edits that do not change the meaning of the
policy being edited.

For an example of such an edit, see PR openssl/general-policies#15

This also adds a reference to this policy from the [Policy on Proposing
General Policy Changes](policies/policy-change-process.md)
