### PR TITLE
Add vote announcement to voting procedure

### DIFF
--- a/policies/voting-procedure.md
+++ b/policies/voting-procedure.md
@@ -17,6 +17,11 @@ pull request of the policy change proposal.
 
 Any other votes are recorded as separate issues in the repository.
 
+All votes governed by this procedure must be announced through an
+e-mail to the [OpenSSL Project mailing list].
+The announcement email must contain a hyperlink to the GitHub issue
+or pull request where the vote is carried out.
+
 Casting the Votes
 -----------------
 
@@ -73,3 +78,4 @@ change and the vote passed the pull request for the policy change is squashed
 and merged into the repository.
 
 [OMC]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#omc
+[OpenSSL Project mailing list]: https://mta.openssl.org/mailman/listinfo/openssl-project


### PR DESCRIPTION
Simple adjustment of the voting procedure to announce votes via openssl-project ML.