### PR TITLE
Update primary target version information

### DIFF
--- a/policy-supplemental/platforms.md
+++ b/policy-supplemental/platforms.md
@@ -1,16 +1,16 @@
 ## Current primary platforms
 
-| Target           | &nbsp; | O/S                   | &nbsp; | Architecture | &nbsp; | Toolchain                            |
-|------------------|--------|-----------------------|--------|--------------|--------|--------------------------------------|
-| linux-x86\_64    |        | Ubuntu Server 20.04.3 |        | x86\_64      |        | gcc 9.3.0                            |
-| linux-generic64  |        | Ubuntu Server 20.04.3 |        | x86\_64      |        | gcc 9.3.0                            |
-| linux-x86        |        | Debian 11.2           |        | x86          |        | gcc 11.2.0                           |
-| linux-generic32  |        | Debian 11.2           |        | x86          |        | gcc 11.2.0                           |
-| BSD-x86\_64      |        | FreeBSD 13.0          |        | x86\_64      |        | Clang 11                             |
-| VC-WIN64A        |        | Windows 10            |        | x86\_64      |        | Visual Studio 2019 Community Edition |
-| mingw64          |        | Windows 10            |        | x86\_64      |        | MinGW (64 bit) and MSYS2             |
-| darwin64-x86\_64 |        | Mac OS Big Sur (11)   |        | x86\_64      |        | clang 12.?                           |
-| darwin64-arm64   |        | Mac OS Big Sur (11)   |        | AArch64 (M1) |        | clang 12.?                           |
+| Target           | &nbsp; | O/S                 | &nbsp; | Architecture | &nbsp; | Toolchain                            |
+|------------------|--------|---------------------|--------|--------------|--------|--------------------------------------|
+| linux-x86\_64    |        | Ubuntu Server 20.04 |        | x86\_64      |        | gcc 9                                |
+| linux-generic64  |        | Ubuntu Server 20.04 |        | x86\_64      |        | gcc 9                                |
+| linux-x86        |        | Debian 11           |        | x86          |        | gcc 11                               |
+| linux-generic32  |        | Debian 11           |        | x86          |        | gcc 11                               |
+| BSD-x86\_64      |        | FreeBSD 13.0        |        | x86\_64      |        | Clang 11                             |
+| VC-WIN64A        |        | Windows 10          |        | x86\_64      |        | Visual Studio 2019 Community Edition |
+| mingw64          |        | Windows 10          |        | x86\_64      |        | MinGW (64 bit) and MSYS2             |
+| darwin64-x86\_64 |        | Mac OS Big Sur (11) |        | x86\_64      |        | Apple clang 13                       |
+| darwin64-arm64   |        | Mac OS Big Sur (11) |        | AArch64 (M1) |        | Apple clang 12                       |
 
 ## Current secondary platforms
 

--- a/policy-supplemental/platforms.md
+++ b/policy-supplemental/platforms.md
@@ -4,8 +4,8 @@
 |------------------|--------|---------------------|--------|--------------|--------|--------------------------------------|
 | linux-x86\_64    |        | Ubuntu Server 20.04 |        | x86\_64      |        | gcc 9                                |
 | linux-generic64  |        | Ubuntu Server 20.04 |        | x86\_64      |        | gcc 9                                |
-| linux-x86        |        | Debian 11           |        | x86          |        | gcc 11                               |
-| linux-generic32  |        | Debian 11           |        | x86          |        | gcc 11                               |
+| linux-x86        |        | Debian 11           |        | x86          |        | gcc 10                               |
+| linux-generic32  |        | Debian 11           |        | x86          |        | gcc 10                               |
 | BSD-x86\_64      |        | FreeBSD 13.0        |        | x86\_64      |        | Clang 11                             |
 | VC-WIN64A        |        | Windows 10          |        | x86\_64      |        | Visual Studio 2019 Community Edition |
 | mingw64          |        | Windows 10          |        | x86\_64      |        | MinGW (64 bit) and MSYS2             |


### PR DESCRIPTION
Some platform and toolchain versions weren't up to date, and quite a few
versions were over-specified.  Now updated, and aligned with the version
numbers that vendors themselves use as references, to the best of our
knowledge.
