### PR TITLE
Modify the commit workflow to allow some unrecorded reviews

### DIFF
--- a/policies/committer-policy.md
+++ b/policies/committer-policy.md
@@ -75,12 +75,16 @@ or committers with `@openssl/committers`.
 
 ## Commit workflow
 
-We do code reviews on GitHub.  The OpenSSL GitHub repository is a mirror,
-so we do not merge on GitHub.  When you become a committer, we'll send
-you instructions to get commit access to the main repository.  To have
-handy links to review history, we record the reviewers and GitHub pull
-request IDs in commit headers.  We have some helper scripts in the tools
-repo to add these headers automatically.
+Code changes are submitted on Github as pull requests, which are subject to
+peer review.  The OpenSSL GitHub repository is a mirror, so we do not merge
+on GitHub.  When you become a committer, we'll send you instructions to get
+commit access to the main repository.  To have handy links to review
+history, we record the reviewers and GitHub pull request IDs in commit
+headers.  We have some helper scripts in the tools repo to add these headers
+automatically.
+
+Some commits, created and signed by OpenSSL designated bots, may be reviewed
+by other means, and do not receive review records as described above.
 
 We don't use merge commits.
 


### PR DESCRIPTION
This is connected to the effort to have releases being staged automatically.
The automaton that performs this sort of staging cannot know who's going to
be the reviewer, so our previous habit of pre-setting the commits with the
intended reviewer is not possible to do any more, and changing them later
with addrev would remove any signature the automaton adds, for example on
the release tag.

We therefore need to make an exception with such commits.

Fixes #49
