### PR TITLE
Allow two reviews by committers for PRs

### DIFF
--- a/policies/committer-policy.md
+++ b/policies/committer-policy.md
@@ -36,9 +36,8 @@ may also be revoked by the OMC.
 
 ## Approvals and code reviews
 
-All submissions must be reviewed and approved by at least two committers,
-one of whom must also be an OTC member.  Neither of the reviewers can
-be the author of the submission.
+All submissions must be reviewed and approved by at least two committers.
+Neither of the reviewers can be the author of the submission.
 
 The sole exception to this is during the release process where the
 author's review does count towards the two needed for the automated


### PR DESCRIPTION
Change the committer policy to remove the requirement for an OTC approval and replace with any committer approval, i.e. 2 committers who aren't the author are now required to approve a PR - no OTC involvement is necessary.