### PR TITLE
Exempt feature branches from the 24 hour delay for merging

### DIFF
--- a/policies/committer-policy.md
+++ b/policies/committer-policy.md
@@ -59,6 +59,10 @@ delay from the approval.  An exception to the delay exists for build and
 test breakage fix approvals which should be flagged with the _severity:
 urgent_ label.
 
+Given that feature branches are merged to the mainline branch via a separate PR,
+PR submissions to the feature branch which are otherwise approved are exempted
+from the 24-hour delay above.
+
 The use of the _severity: urgent_ label should be limited to contexts where the
 breakage of the CI builds and tests (including buildbot) happened within the
 last 72 hours and the change is straightforward.


### PR DESCRIPTION
Because our feature branch policy indicates that the merge of a feature branch to the master branch requires a separate PR, it seems like it might be prudent to exempt PR's targeting the feature branch from the same 24-hour delay.  Providing this extension would allow for faster development cycles when constructing new features