### PR TITLE
Edit links

### DIFF
--- a/policies/TrademarkPolicy.md
+++ b/policies/TrademarkPolicy.md
@@ -204,4 +204,4 @@ any legally available options:
 For any queries with respect to The Policy, please send an email to
 [legal@openssl.org](mailto:legal@openssl.org).
 
-[Trademark Register]: (.../general-policies/policy-supplemental/TrademarkRegister.md)
+[Trademark Register]: /policies/general-supplemental/trademarkregister/

--- a/policies/accessing-sensitive-information-policy.md
+++ b/policies/accessing-sensitive-information-policy.md
@@ -109,5 +109,5 @@ information resources is found in violation of The Policy they may be subject
 to disciplinary action, up to and including termination of any contractual 
 arrangements.
 
-[Sensitive Information Table]: ../policy-supplemental/AccessSensitiveInfoPolicy_SIT.md
-[Sensitive Information Access Table]: ../policy-supplemental/AccessSensitiveInfoPolicy_SIAT.md
+[Sensitive Information Table]: /policies/general-supplemental/accesssensitiveinfopolicy_sit/
+[Sensitive Information Access Table]: /policies/general-supplemental/accesssensitiveinfopolicy_siat/

--- a/policies/committer-policy.md
+++ b/policies/committer-policy.md
@@ -108,11 +108,11 @@ spelling mistake).  All reviewers and the submission author need to
 agree that a submission is trivial and the _cla: trivial_ label should
 be applied to indicate this.
 
-[Contributor Agreements]: https://www.openssl.org/policies/cla.html
+[Contributor Agreements]: /policies/cla/
 [OpenSSL Bylaws]: https://www.openssl.org/policies/omc-bylaws.html
-[OMC]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#omc
-[OTC]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#otc
-[CLAs]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#cla
-[NEWS]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#news
-[CHANGES]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#changes
-[OpenSSL Bylaws]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#bylaws
+[OMC]: /policies/general/glossary/#omc
+[OTC]: /policies/general/glossary/#otc
+[CLAs]: /policies/general/glossary/#cla
+[NEWS]: /policies/general/glossary/#news
+[CHANGES]: /policies/general/glossary/#changes
+[OpenSSL Bylaws]: /policies/general/glossary/#bylaws

--- a/policies/contractors-invoicing-policy.md
+++ b/policies/contractors-invoicing-policy.md
@@ -24,5 +24,5 @@ The OpenSSL organization is purely remote without any office. The organization h
 * Additional expenses as approved can be included, subject to the expenses reimbursement process to ensure the expenses are itemized in the right way for tax (etc). Email expense reimbursements and the supporting documentation directly to the finance@openssl.org mailing list.
 * Manager to batch payments (contractors expenses, invoices) as much as possible, to have a maximum of two potential payment dates a month, and communicate that to contractors.
 
-[Payment Run Schedule Table]: ../general-supplemental/Payment-Run-Schedule-Table.html
+[Payment Run Schedule Table]: /policies/general-supplemental/payment-run-schedule-table/
 [Online Form]: https://docs.google.com/forms/d/e/1FAIpQLSeArUbveC_v_k39khbBc_PgE_qLRk3kBAd_j-0tc-knx-0bYA/viewform

--- a/policies/feature-branch-approval-policy.md
+++ b/policies/feature-branch-approval-policy.md
@@ -50,6 +50,6 @@ feature branch. However this PR review stage enables a final check to confirm
 the complete feature is sane. Once this PR is merged, the feature branch should
 then be deleted from the repository.
 
-[Time-based Release Policy]: https://github.com/openssl/general-policies/blob/master/policies/release-policy.md
+[Time-based Release Policy]: /policies/general/release-policy/
 [Project Board]: https://github.com/orgs/openssl/projects/2/views/28
 [openssl/project]: https://github.com/openssl/project

--- a/policies/glossary.md
+++ b/policies/glossary.md
@@ -174,24 +174,23 @@ A stable release is one where the permitted changes are minimised.
 Refer to the [stable release updates policy] for specific details.
 
 
-[alpha release]: https://github.com/openssl/general-policies/blob/master/policies/versioning-policy.md#alpha-release
-[beta release]: https://github.com/openssl/general-policies/blob/master/policies/versioning-policy.md#beta-release
-[committers]: https://github.com/openssl/general-policies/blob/master/policies/committer-policy.md
-[Long term support]: https://github.com/openssl/general-policies/blob/master/policies/versioning-policy.md#long-term-stable-release
-[major release]: https://github.com/openssl/general-policies/blob/master/policies/versioning-policy.md#major-release
-[minor release]: https://github.com/openssl/general-policies/blob/master/policies/versioning-policy.md#minor-release
-[patch release]: https://github.com/openssl/general-policies/blob/master/policies/versioning-policy.md#patch-release
-[versioning policy]: https://github.com/openssl/general-policies/blob/master/policies/versioning-policy.md
-[stable release updates policy]: https://github.com/openssl/technical-policies/blob/master/policies/stable-release-updates.md
-[testing policy]: https://github.com/openssl/technical-policies/blob/master/policies/testing.md
-[documentation policy]: https://github.com/openssl/technical-policies/blob/master/policies/documentation-policy.md#language
-[API compatibility policy]: https://github.com/openssl/technical-policies/blob/master/policies/api-compat.md
+[alpha release]: /policies/general/versioning-policy/#alpha-release
+[beta release]: /policies/general/versioning-policy/#beta-release
+[committers]: /policies/general/committer-policy/
+[Long term support]: /policies/general/versioning-policy/#long-term-stable-release
+[major release]: /policies/general/versioning-policy/#major-release
+[minor release]: /policies/general/versioning-policy/#minor-release
+[patch release]: /policies/general/versioning-policy/#patch-release
+[versioning policy]: /policies/general/versioning-policy/
+[stable release updates policy]: /policies/technical/stable-release-updates/
+[testing policy]: /policies/technical/testing/
+[documentation policy]: /policies/technical/documentation-policy/#language
+[API compatibility policy]: /policies/technical/api-compat/
 [perlasm README]: https://github.com/openssl/openssl/blob/master/crypto/perlasm/README.md
-[ICLA]: https://www.openssl.org/policies/openssl_icla.pdf
-[CCLA]: https://www.openssl.org/policies/openssl_ccla.pdf
-[Contributor Agreements]: https://www.openssl.org/policies/cla.html
+[ICLA]: /policies/openssl_icla.pdf
+[CCLA]: /policies/openssl_ccla.pdf
+[Contributor Agreements]: /policies/cla/
 [OpenSSL Bylaws]: https://www.openssl.org/policies/omc-bylaws.html
 [CHANGES.md]: https://github.com/openssl/openssl/blob/master/CHANGES.md
 [NEWS.md]: https://github.com/openssl/openssl/blob/master/NEWS.md
-[OpenSSL Bylaws]: https://www.openssl.org/policies/omc-bylaws.html
 [The Linux Documentation Project]: https://tldp.org/

--- a/policies/platform-policy.md
+++ b/policies/platform-policy.md
@@ -4,7 +4,7 @@ Platforms are classified as "primary", "secondary", "community"
 and "unadopted". Support for a new platform should only be added if it
 is being adopted as a primary, secondary or community platform.
 
-[Current platforms](../policy-supplemental/platforms.html)
+[Current platforms](/policies/general-supplemental/platforms/)
 
 ## Primary
 

--- a/policies/policy-change-process.md
+++ b/policies/policy-change-process.md
@@ -78,4 +78,4 @@ should be labelled with the `minor edit` label.
 Approved submissions shall only be applied after a 24-hour delay from the
 approval.
 
-[OMC]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#omc
+[OMC]: /policies/general/glossary/#omc

--- a/policies/release-policy.md
+++ b/policies/release-policy.md
@@ -121,8 +121,8 @@ See [Release Requirements Policy] for details on each type of release.
   fixing security issues, although other bugs may be addressed at the discretion
   of OpenSSL engineering.
 
-[Stable Release Updates Policy]: https://www.openssl.org/policies/technical/stable-release-updates.html
-[Release Requirements Policy]: https://www.openssl.org/policies/technical/release-requirements.html
+[Stable Release Updates Policy]: /policies/technical/stable-release-updates/
+[Release Requirements Policy]: /policies/technical/release-requirements/
 [Making an OpenSSL Release]: https://github.com/openssl/tools/blob/master/HOWTO-make-a-release.md
 
 [^1]: Feature Acceptance Criteria - 🚧 The document is a work in progress.

--- a/policies/security-policy.md
+++ b/policies/security-policy.md
@@ -3,14 +3,14 @@
 ## Reporting security issues
 
 If you wish to report a possible security issue in OpenSSL please
-[notify us](https://www.openssl.org/community/#securityreports).
+[notify us](/community/#reporting-security-bugssecurityreports).
 
 ## Issue triage
 
 Notifications are received by the OMC and OTC. We engage resources within
 OpenSSL to start the investigation and prioritisation. We may work in
 private with individuals who are not on the OMC or OTC as well as other
-organisations and our [employers](https://www.openssl.org/community/thanks.html)
+organisations and our [employers](/community/thanks/)
 where we believe this can help with the issue investigation, resolution, or
 testing.
 
@@ -74,7 +74,7 @@ We use the following severity categories:
 ## Prenotification policy
 
  - Where we are planning an update that fixes security issues we will notify
-   the [openssl-announce list](https://mta.openssl.org/mailman/listinfo/openssl-announce)
+   the [openssl-announce list](https://groups.google.com/a/openssl.org/g/openssl-announce/)
    and update the OpenSSL website to give our scheduled update release date
    and time and the severity of issues being fixed by the update. No further
    information about the issues will be given.

--- a/policies/sponsorship-policy.md
+++ b/policies/sponsorship-policy.md
@@ -132,4 +132,4 @@ Details to be recorded in this system are:
 * Reason for approving sponsorship.
 
 [GitHub Sponsors]: https://github.com/sponsors/openssl
-[Sponsorship webpage]: https://www.openssl.org/support/donations.html
+[Sponsorship webpage]: https://openssl-foundation.org/sponsorship/

--- a/policies/versioning-policy.md
+++ b/policies/versioning-policy.md
@@ -122,12 +122,12 @@ was different and it is detailed here for historic purposes.
   transition to opaque internal structures that occurred with OpenSSL
   release 1.1.0.
 
-[ABI]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#abi
-[API]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#api
-[LTS]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#lts
-[OMC]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#omc
-[major]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#major-release
-[minor]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#minor-release
-[patch]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#patch-release
-[public interfaces]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#public-interface
-[stable release update policy]: https://github.com/openssl/technical-policies/blob/master/policies/stable-release-updates.md
+[ABI]: /policies/general/glossary/#abi
+[API]: /policies/general/glossary/#api
+[LTS]: /policies/general/glossary/#lts
+[OMC]: /policies/general/glossary/#omc
+[major]: /policies/general/glossary/#major-release
+[minor]: /policies/general/glossary/#minor-release
+[patch]: /policies/general/glossary/#patch-release
+[public interfaces]: /policies/general/glossary/#public-interface
+[stable release update policy]: /policies/technical/stable-release-updates/

--- a/policies/voting-procedure.md
+++ b/policies/voting-procedure.md
@@ -72,5 +72,5 @@ The issue is then closed. In case the vote is in a pull request for a policy
 change and the vote passed the pull request for the policy change is squashed
 and merged into the repository.
 
-[OMC]: https://github.com/openssl/general-policies/blob/master/policies/glossary.md#omc
-[OpenSSL Project mailing list]: https://mta.openssl.org/mailman/listinfo/openssl-project
+[OMC]: /policies/general/glossary/#omc
+[OpenSSL Project mailing list]: https://groups.google.com/a/openssl.org/g/openssl-project

--- a/policy-supplemental/AccessSensitiveInfoPolicy_SIAT.md
+++ b/policy-supplemental/AccessSensitiveInfoPolicy_SIAT.md
@@ -1,6 +1,7 @@
 # Sensitive Information Access Table
 
 | **Role/Individual** 	| **Accessible Sensitive Information** 	|
+|-----------------------|---------------------------------------|
 | OMC Member 	| All sensitive information (excluding OTC private votes and fipslab organisation repositories in GHE) 	|
 | OTC Member 	| Security Vulnerabilities, Security Reports 	|
 | OSS Director 	|  	|

--- a/policy-supplemental/TrademarkRegister.md
+++ b/policy-supplemental/TrademarkRegister.md
@@ -1,5 +1,6 @@
 # Authorised Trademark Register
 
 | **Requestor Name** | **Date Decided** | **Approved/Declined** | **Reason for Decision** | **Approval Type** | **Approved Usage** |
+|--------------------|------------------|-----------------------|-------------------------|-------------------|--------------------|
 | OpenSSL Validation Services, Inc. | TBA | Approved | while not affiliated with the OpenSSL project has historical rights to use the OpenSSL trademark. | License Agreement | full usage |
 | ExampleOrg | 2022-11-25 | Approved | Beneficial to OSSL to involved with this organisaiton | Written Authorisation | Including "based on OpenSSL" in their Super Services product |

--- a/policy-supplemental/platforms.md
+++ b/policy-supplemental/platforms.md
@@ -1,3 +1,5 @@
+# Current platforms
+
 ## Current primary platforms
 
 | Target           | &nbsp; | O/S                 | &nbsp; | Architecture | &nbsp; | Toolchain                            |


### PR DESCRIPTION
`General Policies` section on `openssl-library.org` is generated from this repository. Therefore links in these documents must be adapted to work primarily on the website.