### PR TITLE
Create an OpenSSL AI policy

### DIFF
--- a/policies/ai-policy.md
+++ b/policies/ai-policy.md
@@ -1,0 +1,142 @@
+# OpenSSL AI Policy
+
+## Overview
+
+OpenSSL welcomes contributions from all developers, including those who use
+AI-assisted coding tools. This policy sets out the rules for using such tools
+when contributing to OpenSSL.
+
+This policy applies to all public OpenSSL repositories, including all
+repositories under [https://github.com/openssl](https://github.com/openssl).
+
+These rules exist to protect OpenSSL's users, its license integrity, and the
+legal clarity of its codebase.
+
+---
+
+## The Two Core Requirements
+
+If AI has written **non-trivial portions** of your submission, you must:
+
+1. **Declare it in your commit message** using a `Assisted-by` trailer, and
+2. **Have signed a CLA that includes the AI clause.**
+
+Both requirements apply together. Neither alone is sufficient.
+
+---
+
+## 1. Declaring AI Contributions
+
+### What counts as "non-trivial"?
+
+AI has written a non-trivial portion of a submission when it has generated
+meaningful code, logic, or documentation — not merely assisted with trivial
+tasks like autocompletion of a single line, reformatting, or spell-checking.
+
+If in doubt, declare it.
+
+### How to declare it
+
+Add an `Assisted-by` trailer to your commit message in the format
+`Assisted-by: {harness}:{model}`, where `{harness}` is the tool or interface
+you used and `{model}` is the specific underlying model. Always include the
+model name and version where known, so that the declaration is meaningful:
+
+```
+Assisted-by: Claude:claude-sonnet-4-6
+Assisted-by: ChatGPT:gpt-4o
+Assisted-by: GitHub Copilot:gpt-4.1
+```
+
+Note that tools like GitHub Copilot and ChatGPT support multiple underlying
+models (including models from Anthropic, Google, and others). Declare the
+specific model you actually used, not just the tool name.
+
+A commit may have more than one `Assisted-by` trailer if multiple tools
+were used.
+
+### Where to put it
+
+Trailers go at the end of the commit message, separated from the body by a
+blank line:
+
+```
+Fix memory leak in EVP_PKEY handling
+
+Rewrite the cleanup path in evp_pkey_free() to correctly release
+resources when an error occurs during initialisation.
+
+Assisted-by: Claude:claude-sonnet-4-6
+```
+
+---
+
+## 2. The CLA Requirement
+
+OpenSSL has issued a new version of its CLA which includes an AI clause.
+Before submitting any contribution that includes non-trivial AI-generated
+content, you must have signed this new CLA.
+
+Signing the old CLA is **not** sufficient for AI-assisted contributions, even
+if you have previously signed it. You must sign the new CLA in full — it is
+not possible to simply agree to the AI clause in isolation.
+
+The old CLA remains valid for contributions that do not include non-trivial
+AI-generated content. If you are not using AI assistance, there is no need to
+re-sign.
+
+The new CLA requires that you confirm you have the right to submit the
+AI-generated content and that you accept full responsibility for it.
+
+---
+
+## Your Responsibility
+
+**You are responsible for everything you submit, whether or not AI helped
+write it.**
+
+This means:
+
+- **Review all AI-generated code** before submitting it. Do not submit
+  output you have not read and understood.
+- **Ensure correctness.** AI tools can produce plausible-looking but
+  incorrect, insecure, or inefficient code. Security is critical to OpenSSL —
+  AI-generated code must meet the same standards as any other contribution.
+- **Ensure licence compliance.** Do not submit AI-generated code if you have
+  reason to believe it reproduces third-party copyrighted material in a way
+  that would be incompatible with OpenSSL's licence.
+- **Check for test coverage.** AI-generated code must be accompanied by
+  appropriate tests, just like any other contribution.
+
+The OpenSSL project maintainers may reject or request revision of any
+submission, including AI-assisted ones, that does not meet project standards.
+
+---
+
+## What This Policy Does Not Do
+
+This policy does **not** prohibit the use of AI tools. You are free to use
+whatever tools help you contribute effectively.
+
+This policy does **not** create a lower bar for AI-assisted contributions.
+All code is held to the same quality and security standards regardless of how
+it was written.
+
+---
+
+## Summary
+
+| Situation | What you must do |
+|---|---|
+| AI wrote non-trivial parts of the submission | Add `Assisted-by` trailer; have signed new CLA |
+| AI only helped with trivial tasks (e.g. single-line completion, spell-check) | No special action required |
+| Unsure whether the contribution is "non-trivial" | Declare it anyway |
+
+---
+
+## Questions
+
+If you are unsure whether your use of AI tools requires declaration, or if you
+have questions about the CLA, please ask in the
+[OpenSSL GitHub Discussions Q&A forum](https://github.com/openssl/openssl/discussions/categories/q-a)
+before submitting.

--- a/policies/ai-policy.md
+++ b/policies/ai-policy.md
@@ -96,7 +96,7 @@ write it.**
 This means:
 
 - **Review all AI-generated code** before submitting it. Do not submit
-  output you have not read and understood.
+  output you have not read, understood and tested.
 - **Ensure correctness.** AI tools can produce plausible-looking but
   incorrect, insecure, or inefficient code. Security is critical to OpenSSL —
   AI-generated code must meet the same standards as any other contribution.

--- a/policies/ai-policy.md
+++ b/policies/ai-policy.md
@@ -16,7 +16,8 @@ legal clarity of its codebase.
 
 ## The Two Core Requirements
 
-If AI has written **non-trivial portions** of your submission, you must:
+If a **non-trivial portion** of your submission has been created using an
+AI tool you must:
 
 1. **Declare it in your commit message** using an `Assisted-by` trailer, and
 2. **Have signed a CLA that includes the AI clause.**
@@ -29,16 +30,17 @@ Both requirements apply together. Neither alone is sufficient.
 
 ### What counts as "non-trivial"?
 
-AI has written a non-trivial portion of a submission when it has generated
-meaningful code, logic, or documentation — not merely assisted with trivial
-tasks like autocompletion of a single line, reformatting, or spell-checking.
+A non-trivial portion of a submission has been created with an AI tool when it
+has generated meaningful code, logic, or documentation — not merely assisted
+with trivial tasks like autocompletion of a single line, reformatting, or
+spell-checking.
 
-If in doubt, declare it.
+If in doubt, declare it as a non-trival contribution.
 
 ### How to declare it
 
 Add an `Assisted-by` trailer to your commit message in the format
-`Assisted-by: {harness}:{model}`, where `{harness}` is the tool or interface
+`Assisted-by: {agent}:{model}`, where `{agent}` is the tool or interface
 you used and `{model}` is the specific underlying model. Always include the
 model name and version where known, so that the declaration is meaningful:
 
@@ -114,8 +116,8 @@ This policy does **not** prohibit the use of AI tools. You are free to use
 whatever tools help you contribute effectively.
 
 This policy does **not** create a lower bar for AI-assisted contributions.
-All code is held to the same quality and security standards regardless of how
-it was written.
+All code is held to the same quality, legal and security standards regardless of
+how it was written.
 
 This policy does **not** permit submissions where no human has reviewed the
 content. AI may assist, but a human must direct the work, review the output,

--- a/policies/ai-policy.md
+++ b/policies/ai-policy.md
@@ -18,7 +18,7 @@ legal clarity of its codebase.
 
 If AI has written **non-trivial portions** of your submission, you must:
 
-1. **Declare it in your commit message** using a `Assisted-by` trailer, and
+1. **Declare it in your commit message** using an `Assisted-by` trailer, and
 2. **Have signed a CLA that includes the AI clause.**
 
 Both requirements apply together. Neither alone is sufficient.
@@ -48,17 +48,13 @@ Assisted-by: ChatGPT:gpt-4o
 Assisted-by: GitHub Copilot:gpt-4.1
 ```
 
-Note that tools like GitHub Copilot and ChatGPT support multiple underlying
-models (including models from Anthropic, Google, and others). Declare the
-specific model you actually used, not just the tool name.
-
 A commit may have more than one `Assisted-by` trailer if multiple tools
 were used.
 
 ### Where to put it
 
-Trailers go at the end of the commit message, separated from the body by a
-blank line:
+[Trailers](https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-trailer)
+go at the end of the commit message, separated from the body by a blank line:
 
 ```
 Fix memory leak in EVP_PKEY handling
@@ -73,7 +69,7 @@ Assisted-by: Claude:claude-sonnet-4-6
 
 ## 2. The CLA Requirement
 
-OpenSSL has issued a new version of its CLA which includes an AI clause.
+OpenSSL has issued a new version of its CLA, which includes an AI clause.
 Before submitting any contribution that includes non-trivial AI-generated
 content, you must have signed this new CLA.
 
@@ -102,9 +98,8 @@ This means:
 - **Ensure correctness.** AI tools can produce plausible-looking but
   incorrect, insecure, or inefficient code. Security is critical to OpenSSL —
   AI-generated code must meet the same standards as any other contribution.
-- **Ensure licence compliance.** Do not submit AI-generated code if you have
-  reason to believe it reproduces third-party copyrighted material in a way
-  that would be incompatible with OpenSSL's licence.
+- **Avoid copyright violations.** Do not submit AI-generated code if you have
+  reason to believe it reproduces third-party copyrighted material.
 - **Check for test coverage.** AI-generated code must be accompanied by
   appropriate tests, just like any other contribution.
 
@@ -121,6 +116,10 @@ whatever tools help you contribute effectively.
 This policy does **not** create a lower bar for AI-assisted contributions.
 All code is held to the same quality and security standards regardless of how
 it was written.
+
+This policy does **not** permit submissions where no human has reviewed the
+content. AI may assist, but a human must direct the work, review the output,
+and be accountable for what is submitted.
 
 ---
 

--- a/policies/ai-policy.md
+++ b/policies/ai-policy.md
@@ -1,10 +1,11 @@
-# OpenSSL AI Policy
+# OpenSSL AI Code and Documentation Contribution Policy
 
 ## Overview
 
 OpenSSL welcomes contributions from all developers, including those who use
 AI-assisted coding tools. This policy sets out the rules for using such tools
-when contributing to OpenSSL.
+when creating commits for submission to OpenSSL. It applies to anyone that
+creates such commits (including both project committers and non-committers).
 
 This policy applies to all public OpenSSL repositories, including all
 repositories under [https://github.com/openssl](https://github.com/openssl).
@@ -17,10 +18,10 @@ legal clarity of its codebase.
 ## The Two Core Requirements
 
 If a **non-trivial portion** of your submission has been created using an
-AI tool you must:
+AI tool, you must:
 
-1. **Declare it in your commit message** using an `Assisted-by` trailer, and
-2. **Have signed a CLA that includes the AI clause.**
+1. **declare it in your commit message** using an `Assisted-by` trailer, and
+2. **have signed a Contributor License Agreement (CLA) that includes the AI clauses.**
 
 Both requirements apply together. Neither alone is sufficient.
 
@@ -71,9 +72,9 @@ Assisted-by: Claude:claude-sonnet-4-6
 
 ## 2. The CLA Requirement
 
-OpenSSL has issued a new version of its CLA, which includes an AI clause.
-Before submitting any contribution that includes non-trivial AI-generated
-content, you must have signed this new CLA.
+OpenSSL has issued a new version of its [CLA](https://openssl-library.org/policies/cla/),
+which includes clauses related to AI. Before submitting any contribution that
+includes non-trivial AI-generated content, you must have signed this new CLA.
 
 Signing the old CLA is **not** sufficient for AI-assisted contributions, even
 if you have previously signed it. You must sign the new CLA in full — it is
@@ -120,8 +121,8 @@ All code is held to the same quality, legal and security standards regardless of
 how it was written.
 
 This policy does **not** permit submissions where no human has reviewed the
-content. AI may assist, but a human must direct the work, review the output,
-and be accountable for what is submitted.
+content. AI tools may assist, but a human must direct the work, review the
+output, and be accountable for what is submitted.
 
 ---
 
@@ -129,8 +130,8 @@ and be accountable for what is submitted.
 
 | Situation | What you must do |
 |---|---|
-| AI wrote non-trivial parts of the submission | Add `Assisted-by` trailer; have signed new CLA |
-| AI only helped with trivial tasks (e.g. single-line completion, spell-check) | No special action required |
+| AI tool used to write non-trivial parts of the submission | Add `Assisted-by` trailer; have signed the new CLA |
+| AI only used to help with trivial tasks (e.g. single-line completion, spell-check) | No special action required |
 | Unsure whether the contribution is "non-trivial" | Declare it anyway |
 
 ---


### PR DESCRIPTION
The key requirements are:
1) Declare your AI usage
2) Have signed a CLA that includes the AI clause

Assisted-by: Claude:claude-sonnet-4-6

This presupposes the existence of some version of the CLA with an AI clause